### PR TITLE
chore: Update brew formula for verscout version 1.6.1

### DIFF
--- a/verscout.rb
+++ b/verscout.rb
@@ -6,21 +6,21 @@ class Verscout < Formula
   desc "Find the latest version tag, calculate the next version, print to STDOUT - no tagging, no bumping, no changelog, no publishing.
 "
   homepage "https://github.com/erNail/verscout"
-  version "1.6.0"
+  version "1.6.1"
   license "MIT"
 
   on_macos do
     on_intel do
-      url "https://github.com/erNail/verscout/releases/download/1.6.0/verscout_1.6.0_darwin_amd64.tar.gz"
-      sha256 "bc3a3ca73bd658484b6bb85d534add0a102367e1517e6d09eae2bb79ce41a3e2"
+      url "https://github.com/erNail/verscout/releases/download/1.6.1/verscout_1.6.1_darwin_amd64.tar.gz"
+      sha256 "9655b86426b8cd35cbe19bec7c35e1af3be6b64549b561da768d198453e3f37c"
 
       def install
         bin.install "verscout"
       end
     end
     on_arm do
-      url "https://github.com/erNail/verscout/releases/download/1.6.0/verscout_1.6.0_darwin_arm64.tar.gz"
-      sha256 "bcace1583a62c56d315dccd498f55d64a2f4d4a71d97c24435df357240e32ee6"
+      url "https://github.com/erNail/verscout/releases/download/1.6.1/verscout_1.6.1_darwin_arm64.tar.gz"
+      sha256 "420700621a9b5a726cb37047c0166062ebee7bb657157b5df3ee07dc0d7815a0"
 
       def install
         bin.install "verscout"
@@ -31,8 +31,8 @@ class Verscout < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/erNail/verscout/releases/download/1.6.0/verscout_1.6.0_linux_amd64.tar.gz"
-        sha256 "b724397be72914fbac5e07e4c216b209ceb68b482fb35419b82a58a77213fb52"
+        url "https://github.com/erNail/verscout/releases/download/1.6.1/verscout_1.6.1_linux_amd64.tar.gz"
+        sha256 "00abfead788ccdc05be164281f7a547ed4c71e9491ca5ac663b3022873bf2128"
 
         def install
           bin.install "verscout"
@@ -41,8 +41,8 @@ class Verscout < Formula
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/erNail/verscout/releases/download/1.6.0/verscout_1.6.0_linux_arm64.tar.gz"
-        sha256 "ecde22c5f6f34efda7f16d4d2c76397cc16c22bb097a83f65a61ea975eb9b250"
+        url "https://github.com/erNail/verscout/releases/download/1.6.1/verscout_1.6.1_linux_arm64.tar.gz"
+        sha256 "d2884064e187017cd55fea42ea1f4bf57b19dbf278a42caf76f1785a0c23fa3a"
 
         def install
           bin.install "verscout"


### PR DESCRIPTION

###### Automated with [GoReleaser](https://goreleaser.com)